### PR TITLE
feat: Merge migrations for carriers removal and status field removal

### DIFF
--- a/migrations/versions/5d0056d0be5d_merge_migrations_carriers_removal_and_.py
+++ b/migrations/versions/5d0056d0be5d_merge_migrations_carriers_removal_and_.py
@@ -1,0 +1,23 @@
+"""Merge migrations: carriers removal and status field removal
+
+Revision ID: 5d0056d0be5d
+Revises: 6b5a7d58d5c4, a975eddf0d3d
+Create Date: 2025-08-22 18:14:49.556109
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "5d0056d0be5d"
+down_revision: Union[str, Sequence[str], None] = ("6b5a7d58d5c4", "a975eddf0d3d")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
This commit introduces a new Alembic migration that merges the changes related to the removal of the carriers table and the status field from the Loads API. The migration is identified by revision ID 5d0056d0be5d and includes the necessary identifiers for tracking. The upgrade and downgrade functions are defined but currently do not implement any changes.

This migration supports the ongoing efforts to streamline the API and database schema, ensuring that all related infrastructure is aligned with the latest design decisions.