### PR TITLE
refactor: remove cacheFrom configuration in Docker image build process

### DIFF
--- a/infrastructure/pulumi/components/containers.ts
+++ b/infrastructure/pulumi/components/containers.ts
@@ -66,9 +66,6 @@ export class ContainersComponent extends pulumi.ComponentResource {
             // The image will be tagged with a hash of the build context
             // This ensures we only rebuild when source files actually change
             imageName: pulumi.interpolate`${this.apiRepository.repositoryUrl}:${args.environment}`,
-            cacheFrom: {
-                stages: ["build", "runtime"], // Cache intermediate build stages if your Dockerfile uses multi-stage builds
-            },
             args: {
                 // Build args if needed
                 BUILDKIT_INLINE_CACHE: "1", // Enable inline cache for better caching

--- a/infrastructure/pulumi/components/containers.ts
+++ b/infrastructure/pulumi/components/containers.ts
@@ -1,5 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import * as path from "path";
 
 export interface ContainersArgs {
     vpc: aws.ec2.Vpc;
@@ -53,6 +55,25 @@ export class ContainersComponent extends pulumi.ComponentResource {
             },
         }, { parent: this });
 
+        // Build and push Docker image to ECR
+        // This will only rebuild if the Docker context or Dockerfile changes
+        // Pulumi automatically tracks file changes and only rebuilds when necessary
+        const apiImage = new awsx.ecr.Image(`${name}-api-image`, {
+            repositoryUrl: this.apiRepository.repositoryUrl,
+            context: path.resolve(__dirname, "../../../.."), // Path to the root of the project
+            dockerfile: path.resolve(__dirname, "../../../../Dockerfile.api"),
+            platform: "linux/amd64", // Ensure compatibility with Fargate
+            // The image will be tagged with a hash of the build context
+            // This ensures we only rebuild when source files actually change
+            imageName: pulumi.interpolate`${this.apiRepository.repositoryUrl}:${args.environment}`,
+            cacheFrom: {
+                stages: ["build", "runtime"], // Cache intermediate build stages if your Dockerfile uses multi-stage builds
+            },
+            args: {
+                // Build args if needed
+                BUILDKIT_INLINE_CACHE: "1", // Enable inline cache for better caching
+            },
+        }, { parent: this });
 
         // Create lifecycle policies for ECR repositories
         new aws.ecr.LifecyclePolicy(`${name}-api-lifecycle`, {
@@ -203,16 +224,16 @@ export class ContainersComponent extends pulumi.ComponentResource {
             executionRoleArn: this.executionRole.arn,
             taskRoleArn: this.taskRole.arn,
             containerDefinitions: pulumi.all([
-                this.apiRepository.repositoryUrl,
+                apiImage.imageUri,
                 args.databaseEndpoint,
                 args.databaseSecretArn,
                 apiLogGroup.name,
-            ]).apply(([repositoryUrl, dbEndpoint, secretArn, logGroupName]) => {
+            ]).apply(([imageUri, dbEndpoint, secretArn, logGroupName]) => {
                 const containerName = `${name}-api`;
                 return JSON.stringify([
                 {
                     name: containerName,
-                    image: `${repositoryUrl}:latest`,
+                    image: imageUri,
                     essential: true,
                     portMappings: [
                         {


### PR DESCRIPTION
This commit simplifies the Docker image build configuration in the ContainersComponent by removing the cacheFrom property, which was previously set to cache intermediate build stages. This change streamlines the build process while maintaining efficient image rebuilding based on source file changes.